### PR TITLE
mysql_query requires mysqli link - missed for plot.php

### DIFF
--- a/web/plot.php
+++ b/web/plot.php
@@ -38,9 +38,9 @@ if (!$source_is_fahrenheit && $use_fahrenheit) { //From Celsius to Fahrenheit
 
 // Grab the session number
 if (isset($_GET["id"]) and in_array($_GET["id"], $sids)) {
-    $session_id = mysqli_real_escape_string($_GET['id']);
+    $session_id = mysqli_real_escape_string($con, $_GET['id']);
     // Get the torque key->val mappings
-    $keyquery = mysqli_query("SELECT id,description,units FROM $db_name.$db_keys_table;") or die(mysqli_error($con));
+    $keyquery = mysqli_query($con, "SELECT id,description,units FROM $db_name.$db_keys_table;") or die(mysqli_error($con));
     $keyarr = [];
     while($row = mysqli_fetch_assoc($keyquery)) {
       $keyarr[$row['id']] = array($row['description'], $row['units']);
@@ -55,7 +55,7 @@ if (isset($_GET["id"]) and in_array($_GET["id"], $sids)) {
 		$i = $i + 1;
 	}
 	// Get data for session
-	$sessionqry = mysqli_query("SELECT $selectstring FROM $db_table WHERE session=".quote_value($session_id)." ORDER BY time DESC;") or die(mysqli_error($con));
+	$sessionqry = mysqli_query($con, "SELECT $selectstring FROM $db_table WHERE session=".quote_value($session_id)." ORDER BY time DESC;") or die(mysqli_error($con));
 	while($row = mysqli_fetch_assoc($sessionqry)) {
 	    $i = 1;
 		while (isset(${'v' . $i})) {


### PR DESCRIPTION
Fixes these errors:

Warning: mysqli_real_escape_string() expects exactly 2 parameters, 1 given in /var/wwws/adel.website/htdocs/torque/plot.php on line 41
Warning: mysqli_query() expects at least 2 parameters, 1 given in /var/wwws/adel.website/htdocs/torque/plot.php on line 43
Warning: mysqli_query() expects at least 2 parameters, 1 given in /var/wwws/adel.website/htdocs/torque/plot.php on line 58